### PR TITLE
docs: add index with instructions when an IP is not present in the URL.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,4 @@
+Use the following command to check if your IP is protected by PIA.
+
+curl -s https://lars-.github.io/PIA-servers/$(curl -s https://ipinfo.io/ip)
+


### PR DESCRIPTION
You should include an `index.html` so that you don't return "You are not connected to PIA" when no IP is included in the URL.

```bash
$ curl -s https://lars-.github.io/PIA-servers/
You are not connected to PIA
```

This may not be true and gives the impression that their is server-side logic being run.

Another unrelated suggestion for your update scripts is the add a newline to the IP files you generate so the terminal prompt is on a new line. This is what it looks like right now.

```bash
user@host:~$ curl -s https://lars-.github.io/PIA-servers/$(curl -s https://ipinfo.io/ip)
You are not connected to PIAuser@host:~$ 
```
